### PR TITLE
feature/more scheduling options - monitoring with micrometer support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "com.valensas"
-version = "0.1.1"
+version = "0.2.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-quartz:3.2.0")
     implementation("org.reflections:reflections:0.10.2")
+    implementation("io.micrometer:micrometer-core:1.12.4")
 }
 
 tasks.getByName<Jar>("jar") {

--- a/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
@@ -122,16 +122,11 @@ class JobScheduler(
         }
 
         if (fixedDelayString.isNotBlank()) {
-            var finalFixedDelay =
-                fixedDelayString.toLongOrNull()
-                    .takeIf { it != null } ?: Duration.parse(fixedDelayString).toMillis()
-            var finalInitialDelay =
-                if (initialDelayString.isBlank()) {
-                    0
-                } else {
-                    initialDelayString.toLongOrNull().takeIf { it != null }
-                        ?: Duration.parse(initialDelayString).toMillis()
-                }
+            var finalFixedDelay = fixedDelayString.toLongOrNull()
+                ?: Duration.parse(fixedDelayString).toMillis()
+
+            var finalInitialDelay = initialDelayString.toLongOrNull()
+                ?: Duration.parse(initialDelayString).toMillis()
 
             if (finalFixedDelay < 0) {
                 throw IllegalArgumentException("Fixed delay must be a positive number for job $jobKey")

--- a/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
@@ -123,9 +123,11 @@ class JobScheduler(
 
         if (fixedDelayString.isNotBlank()) {
             var finalFixedDelay =
-                fixedDelayString.toLongOrNull().takeIf { it != null } ?: Duration.parse(fixedDelayString).toMillis()
+                fixedDelayString.toLongOrNull()
+                    .takeIf { it != null } ?: Duration.parse(fixedDelayString).toMillis()
             var finalInitialDelay =
-                initialDelayString.toLongOrNull().takeIf { it != null } ?: Duration.parse(initialDelayString).toMillis()
+                if (initialDelayString.isBlank()) 0 else initialDelayString.toLongOrNull().takeIf { it != null }
+                    ?: Duration.parse(initialDelayString).toMillis()
 
             if (finalFixedDelay < 0) {
                 throw IllegalArgumentException("Fixed delay must be a positive number for job $jobKey")

--- a/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
@@ -122,22 +122,22 @@ class JobScheduler(
         }
 
         if (fixedDelayString.isNotBlank()) {
-            var finalFixedDelay = fixedDelayString.toLongOrNull()
+            var fixedDelay = fixedDelayString.toLongOrNull()
                 ?: Duration.parse(fixedDelayString).toMillis()
 
-            var finalInitialDelay = initialDelayString.toLongOrNull()
+            var initialDelay = initialDelayString.toLongOrNull()
                 ?: Duration.parse(initialDelayString).toMillis()
 
-            if (finalFixedDelay < 0) {
+            if (fixedDelay < 0) {
                 throw IllegalArgumentException("Fixed delay must be a positive number for job $jobKey")
             }
 
             if (scheduleAnnotation.timeUnit != TimeUnit.MILLISECONDS) {
-                finalFixedDelay = scheduleAnnotation.timeUnit.toMillis(finalFixedDelay)
-                finalInitialDelay = scheduleAnnotation.timeUnit.toMillis(finalInitialDelay)
+                fixedDelay = scheduleAnnotation.timeUnit.toMillis(fixedDelay)
+                initialDelay = scheduleAnnotation.timeUnit.toMillis(initialDelay)
             }
 
-            scheduleFixedDelayJob(jobClass, jobKey, finalInitialDelay, finalFixedDelay)
+            scheduleFixedDelayJob(jobClass, jobKey, initialDelay, fixedDelay)
         } else if (cronExpression.isNotBlank()) {
             scheduleCronJob(jobClass, jobKey, cronExpression)
         } else {

--- a/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
@@ -126,8 +126,12 @@ class JobScheduler(
                 fixedDelayString.toLongOrNull()
                     .takeIf { it != null } ?: Duration.parse(fixedDelayString).toMillis()
             var finalInitialDelay =
-                if (initialDelayString.isBlank()) 0 else initialDelayString.toLongOrNull().takeIf { it != null }
-                    ?: Duration.parse(initialDelayString).toMillis()
+                if (initialDelayString.isBlank()) {
+                    0
+                } else {
+                    initialDelayString.toLongOrNull().takeIf { it != null }
+                        ?: Duration.parse(initialDelayString).toMillis()
+                }
 
             if (finalFixedDelay < 0) {
                 throw IllegalArgumentException("Fixed delay must be a positive number for job $jobKey")

--- a/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
@@ -20,7 +20,6 @@ import org.springframework.context.ApplicationListener
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.event.EventListener
 import java.time.Duration
-import java.util.concurrent.TimeUnit
 
 // Need to get the main application class to determine the root package for job scanning at runtime
 @Configuration
@@ -122,19 +121,12 @@ class JobScheduler(
         }
 
         if (fixedDelayString.isNotBlank()) {
-            var fixedDelay = fixedDelayString.toLongOrNull()
-                ?: Duration.parse(fixedDelayString).toMillis()
+            val fixedDelay = Duration.parse(fixedDelayString).toMillis()
 
-            var initialDelay = initialDelayString.toLongOrNull()
-                ?: Duration.parse(initialDelayString).toMillis()
+            val initialDelay = Duration.parse(initialDelayString).toMillis()
 
             if (fixedDelay < 0) {
-                throw IllegalArgumentException("Fixed delay must be a positive number for job $jobKey")
-            }
-
-            if (scheduleAnnotation.timeUnit != TimeUnit.MILLISECONDS) {
-                fixedDelay = scheduleAnnotation.timeUnit.toMillis(fixedDelay)
-                initialDelay = scheduleAnnotation.timeUnit.toMillis(initialDelay)
+                throw IllegalArgumentException("Fixed delay must be a positive number for job $jobKey , parsed value $fixedDelay")
             }
 
             scheduleFixedDelayJob(jobClass, jobKey, initialDelay, fixedDelay)

--- a/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
@@ -19,6 +19,7 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationListener
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.event.EventListener
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 // Need to get the main application class to determine the root package for job scanning at runtime
@@ -67,7 +68,18 @@ class JobScheduler(
                     resolveEnvironmentPlaceholders(scheduleAnnotation.jobGroup)
                         .ifBlank { jobClass.`package`.name }
 
-                handleAnnotation(scheduleAnnotation, jobClass, jobName, jobGroup, newJobKeysSet)
+                val jobKey = JobKey.jobKey(jobName, jobGroup)
+
+                val enabled = resolveEnvironmentPlaceholders(scheduleAnnotation.enabled).toBoolean()
+
+                if (!enabled) {
+                    logger.info("Job $jobKey is disabled")
+                    return@let
+                }
+
+                handleAnnotation(scheduleAnnotation, jobClass, jobKey)
+
+                newJobKeysSet.add(jobKey)
             }
         }
 
@@ -94,59 +106,29 @@ class JobScheduler(
             ?: throw IllegalStateException("Unable to determine base package for job scanning")
     }
 
-    private fun handleAnnotation(scheduleAnnotation: QuartzSchedule, jobClass: Class<out Job>, jobName: String, jobGroup: String, newJobKeysSet: MutableSet<JobKey>) {
-        val jobKey = JobKey.jobKey(jobName, jobGroup)
-
+    private fun handleAnnotation(
+        scheduleAnnotation: QuartzSchedule,
+        jobClass: Class<out Job>,
+        jobKey: JobKey
+    ) {
         val cronExpression = resolveEnvironmentPlaceholders(scheduleAnnotation.cron)
 
-        val fixedDelayString = resolveEnvironmentPlaceholders(scheduleAnnotation.fixedDelayString)
+        val fixedDelayString = resolveEnvironmentPlaceholders(scheduleAnnotation.fixedDelay)
 
-        val initialDelayString = resolveEnvironmentPlaceholders(scheduleAnnotation.initialDelayString)
+        val initialDelayString = resolveEnvironmentPlaceholders(scheduleAnnotation.initialDelay)
 
-        val fixedDelay = scheduleAnnotation.fixedDelay
-
-        val initialDelay = scheduleAnnotation.initialDelay
-
-        val fixedDelayParameterSet = fixedDelayString != "" || fixedDelay != -1L
-        val initialDelayParameterSet = initialDelayString != "" || initialDelay != -1L
-        val cronParameterSet = cronExpression != ""
-
-        if (fixedDelayParameterSet && cronParameterSet) {
-            throw IllegalArgumentException("Both fixed delay and cron parameters are set for job $jobName")
+        if (fixedDelayString.isNotBlank() && cronExpression.isNotBlank()) {
+            throw IllegalArgumentException("Both fixed delay and cron parameters are set for job $jobKey")
         }
 
-        if (initialDelayParameterSet && cronParameterSet) {
-            throw IllegalArgumentException("Both initial delay and cron parameters are set for job $jobName")
-        }
+        if (fixedDelayString.isNotBlank()) {
+            var finalFixedDelay =
+                fixedDelayString.toLongOrNull().takeIf { it != null } ?: Duration.parse(fixedDelayString).toMillis()
+            var finalInitialDelay =
+                initialDelayString.toLongOrNull().takeIf { it != null } ?: Duration.parse(initialDelayString).toMillis()
 
-        if (fixedDelayParameterSet) {
-            var finalFixedDelay = if (fixedDelayString != "") {
-                fixedDelayString.toLongOrNull()
-            } else {
-                fixedDelay
-            }
-
-            if (finalFixedDelay == null) {
-                throw IllegalArgumentException("Invalid fixed delay string value for job $jobName")
-            }
-
-            if (finalFixedDelay == -1L) {
-                logger.info("Skipping disabled fixed delay job $jobName")
-                return
-            }
-
-            var finalInitialDelay = if (initialDelayString != "") {
-                initialDelayString.toLongOrNull()
-            } else {
-                initialDelay
-            }
-
-            if (finalInitialDelay == null) {
-                throw IllegalArgumentException("Invalid initial delay string value for job $jobName")
-            }
-
-            if (finalInitialDelay == -1L) {
-                finalInitialDelay = 0L
+            if (finalFixedDelay < 0) {
+                throw IllegalArgumentException("Fixed delay must be a positive number for job $jobKey")
             }
 
             if (scheduleAnnotation.timeUnit != TimeUnit.MILLISECONDS) {
@@ -154,38 +136,31 @@ class JobScheduler(
                 finalInitialDelay = scheduleAnnotation.timeUnit.toMillis(finalInitialDelay)
             }
 
-            scheduleFixedDelayJob(jobClass, jobName, jobGroup, finalInitialDelay, finalFixedDelay)
-        } else if (cronParameterSet) {
-            if (cronExpression == scheduleAnnotation.CRON_DISABLED) {
-                logger.info("Skipping disabled cron job $jobName")
-                return
-            }
-
-            scheduleCronJob(jobClass, jobName, jobGroup, cronExpression)
+            scheduleFixedDelayJob(jobClass, jobKey, finalInitialDelay, finalFixedDelay)
+        } else if (cronExpression.isNotBlank()) {
+            scheduleCronJob(jobClass, jobKey, cronExpression)
         } else {
-            throw IllegalArgumentException("No scheduling parameters provided for job $jobName")
+            throw IllegalArgumentException("No scheduling parameters provided for job $jobKey")
         }
-
-        newJobKeysSet.add(jobKey)
     }
 
     private fun scheduleFixedDelayJob(
         jobClass: Class<out Job>?,
-        jobName: String?,
-        jobGroup: String?,
+        jobKey: JobKey,
         finalInitialDelay: Long,
         finalFixedDelay: Long
     ) {
-        val jobKey = JobKey.jobKey(jobName, jobGroup)
         val newTrigger = TriggerBuilder.newTrigger()
-            .withIdentity(jobName, jobGroup)
-            .forJob(jobName, jobGroup)
-            .withSchedule(SimpleScheduleBuilder.simpleSchedule().withIntervalInMilliseconds(finalFixedDelay).repeatForever())
+            .withIdentity(jobKey.name, jobKey.group)
+            .forJob(jobKey)
+            .withSchedule(
+                SimpleScheduleBuilder.simpleSchedule().withIntervalInMilliseconds(finalFixedDelay).repeatForever()
+            )
             .startAt(java.util.Date(System.currentTimeMillis() + finalInitialDelay))
             .build()
         val jobDetail = JobBuilder.newJob(jobClass)
             .requestRecovery(false)
-            .withIdentity(jobName, jobGroup)
+            .withIdentity(jobKey)
             .storeDurably()
             .build()
 
@@ -196,16 +171,15 @@ class JobScheduler(
         }
     }
 
-    private fun scheduleCronJob(clazz: Class<out Job>, jobName: String, jobGroup: String, cronExpression: String) {
-        val jobKey = JobKey.jobKey(jobName, jobGroup)
+    private fun scheduleCronJob(clazz: Class<out Job>, jobKey: JobKey, cronExpression: String) {
         val newTrigger = TriggerBuilder.newTrigger()
-            .withIdentity(jobName, jobGroup)
-            .forJob(jobName, jobGroup)
+            .withIdentity(jobKey.name, jobKey.group)
+            .forJob(jobKey)
             .withSchedule(CronScheduleBuilder.cronSchedule(cronExpression))
             .build()
         val jobDetail = JobBuilder.newJob(clazz)
             .requestRecovery(false)
-            .withIdentity(jobName, jobGroup)
+            .withIdentity(jobKey)
             .storeDurably()
             .build()
 

--- a/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
@@ -121,9 +121,14 @@ class JobScheduler(
         }
 
         if (fixedDelayString.isNotBlank()) {
-            val fixedDelay = Duration.parse(fixedDelayString).toMillis()
 
-            val initialDelay = Duration.parse(initialDelayString).toMillis()
+            val fixedDelay = Duration.parse(fixedDelayString).toMillis().runCatching { this }.getOrElse {
+                throw IllegalArgumentException("Fixed delay must be a valid duration for job $jobKey , raw value $fixedDelayString")
+            }
+
+            val initialDelay = Duration.parse(initialDelayString).toMillis().runCatching { this }.getOrElse {
+                throw IllegalArgumentException("Initial delay must be a valid duration for job $jobKey , raw value $initialDelayString")
+            }
 
             if (fixedDelay < 0) {
                 throw IllegalArgumentException("Fixed delay must be a positive number for job $jobKey , parsed value $fixedDelay")

--- a/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
@@ -121,7 +121,6 @@ class JobScheduler(
         }
 
         if (fixedDelayString.isNotBlank()) {
-
             val fixedDelay = Duration.parse(fixedDelayString).toMillis().runCatching { this }.getOrElse {
                 throw IllegalArgumentException("Fixed delay must be a valid duration for job $jobKey , raw value $fixedDelayString")
             }

--- a/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
@@ -1,9 +1,28 @@
 package com.valensas.simplyquartz
 
+import org.springframework.scheduling.annotation.Scheduled
+import java.util.concurrent.TimeUnit
+
+@Scheduled()
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class QuartzSchedule(
-    val cron: String,
+
+    val cron: String = "",
+
+    val fixedDelay: Long = -1L,
+
+    val fixedDelayString: String = "",
+
+    val initialDelay: Long = -1L,
+
+    val initialDelayString: String = "",
+
+    val timeUnit: TimeUnit = TimeUnit.MILLISECONDS,
+
+    val CRON_DISABLED: String = "-",
+
     val jobName: String = "",
+
     val jobGroup: String = ""
 )

--- a/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
@@ -1,7 +1,8 @@
 package com.valensas.simplyquartz
 
-import java.util.concurrent.TimeUnit
+import org.springframework.scheduling.annotation.Scheduled
 
+@Scheduled
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class QuartzSchedule(
@@ -10,9 +11,7 @@ annotation class QuartzSchedule(
 
     val fixedDelay: String = "",
 
-    val initialDelay: String = "0",
-
-    val timeUnit: TimeUnit = TimeUnit.MILLISECONDS,
+    val initialDelay: String = "PT0S",
 
     val enabled: String = "true",
 

--- a/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
@@ -14,7 +14,7 @@ annotation class QuartzSchedule(
 
     val timeUnit: TimeUnit = TimeUnit.MILLISECONDS,
 
-    val enabled: String = "",
+    val enabled: String = "true",
 
     val jobName: String = "",
 

--- a/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
@@ -9,10 +9,6 @@ annotation class QuartzSchedule(
 
     val cron: String = "",
 
-    val fixedDelay: String = "",
-
-    val initialDelay: String = "PT0S",
-
     val enabled: String = "true",
 
     val jobName: String = "",

--- a/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
@@ -1,26 +1,20 @@
 package com.valensas.simplyquartz
 
-import org.springframework.scheduling.annotation.Scheduled
 import java.util.concurrent.TimeUnit
 
-@Scheduled()
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class QuartzSchedule(
 
     val cron: String = "",
 
-    val fixedDelay: Long = -1L,
+    val fixedDelay: String = "",
 
-    val fixedDelayString: String = "",
-
-    val initialDelay: Long = -1L,
-
-    val initialDelayString: String = "",
+    val initialDelay: String = "",
 
     val timeUnit: TimeUnit = TimeUnit.MILLISECONDS,
 
-    val CRON_DISABLED: String = "-",
+    val enabled: String = "",
 
     val jobName: String = "",
 

--- a/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
@@ -10,7 +10,7 @@ annotation class QuartzSchedule(
 
     val fixedDelay: String = "",
 
-    val initialDelay: String = "",
+    val initialDelay: String = "0",
 
     val timeUnit: TimeUnit = TimeUnit.MILLISECONDS,
 

--- a/src/main/kotlin/com/valensas/simplyquartz/TimedJob.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/TimedJob.kt
@@ -1,0 +1,15 @@
+package com.valensas.simplyquartz
+
+import io.micrometer.core.instrument.Metrics
+import org.quartz.Job
+import org.quartz.JobExecutionContext
+
+abstract class TimedJob : Job {
+    private val timer = Metrics.globalRegistry.timer(this.javaClass.name, "job", "name")
+
+    override fun execute(context: JobExecutionContext) {
+        timer.record<Unit> { executeTimed(context) }
+    }
+
+    protected abstract fun executeTimed(context: JobExecutionContext?)
+}


### PR DESCRIPTION
Added options to the @QuartzSchedule annotation to mirror @Scheduled's initialDelay, initialDelayString, fixedDelay, fixedDelayString, timeUnit, CRON_DISABLED parameters.

Added support for creating jobs that are being traced by micrometer. 

@moray95 @odenizturker