### PR TITLE
Moved from reflections to spring beans to detect jobs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "com.valensas"
-version = "0.2.1"
+version = "1.0.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -40,7 +40,6 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-quartz:3.2.0")
-    implementation("org.reflections:reflections:0.10.2")
     implementation("io.micrometer:micrometer-core:1.12.4")
 }
 
@@ -54,6 +53,19 @@ tasks.withType<KotlinCompile> {
         jvmTarget = "17"
     }
 }
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+        }
+    }
+
+    repositories {
+        mavenLocal()
+    }
+}
+
 
 signing {
     val keyId = System.getenv("SIGNING_KEYID")
@@ -89,5 +101,7 @@ centralPortal {
                 email.set("info@valensas.com")
             }
         }
+
+
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "com.valensas"
-version = "1.0.0"
+version = "0.3.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
@@ -7,27 +7,14 @@ import org.quartz.JobKey
 import org.quartz.Scheduler
 import org.quartz.TriggerBuilder
 import org.quartz.impl.matchers.GroupMatcher
-import org.reflections.Reflections
-import org.reflections.util.ConfigurationBuilder
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.event.ApplicationReadyEvent
-import org.springframework.boot.context.event.ApplicationStartedEvent
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext
-import org.springframework.context.ApplicationListener
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.event.EventListener
 
-// Need to get the main application class to determine the root package for job scanning at runtime
-@Configuration
-class MainClassHolder : ApplicationListener<ApplicationStartedEvent> {
-    var mainApplicationClass: Class<*>? = null
-
-    override fun onApplicationEvent(event: ApplicationStartedEvent) {
-        mainApplicationClass = event.springApplication.mainApplicationClass
-    }
-}
 
 @Configuration
 @ConditionalOnProperty("simplyquartz.enabled", havingValue = "true")
@@ -35,35 +22,24 @@ class MainClassHolder : ApplicationListener<ApplicationStartedEvent> {
 class JobScheduler(
     private val scheduler: Scheduler,
     private val applicationContext: ApplicationContext,
-    private val simplyQuartzProperties: SimplyQuartzProperties,
-    private val mainClassHolder: MainClassHolder
+    private val jobs: List<Job>
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     @EventListener(ApplicationReadyEvent::class)
     fun onApplicationReady() {
         logger.info("Scheduling jobs")
-        scanAndScheduleJobs()
-    }
 
-    private fun scanAndScheduleJobs() {
         val existingJobKeysSet = scheduler.getJobKeys(GroupMatcher.anyGroup()).toSet()
         val newJobKeysSet = mutableSetOf<JobKey>()
 
-        val jobsSearchPackages = determineJobsSearchPathRootPackage()
-        val reflections = Reflections(
-            ConfigurationBuilder()
-                .forPackages(*jobsSearchPackages.toTypedArray())
-        )
-
-        reflections.getSubTypesOf(Job::class.java).forEach { jobClass ->
+        jobs.forEach {
+            val jobClass = it.javaClass
             jobClass.getAnnotation(QuartzSchedule::class.java)?.let { scheduleAnnotation ->
-                val jobName =
-                    resolveEnvironmentPlaceholders(scheduleAnnotation.jobName)
-                        .ifBlank { jobClass.simpleName }
-                val jobGroup =
-                    resolveEnvironmentPlaceholders(scheduleAnnotation.jobGroup)
-                        .ifBlank { jobClass.`package`.name }
+                val jobName = resolveEnvironmentPlaceholders(scheduleAnnotation.jobName)
+                    .ifBlank { jobClass.simpleName }
+                val jobGroup = resolveEnvironmentPlaceholders(scheduleAnnotation.jobGroup)
+                    .ifBlank { jobClass.`package`.name }
 
                 val jobKey = JobKey.jobKey(jobName, jobGroup)
 
@@ -74,9 +50,14 @@ class JobScheduler(
                     return@let
                 }
 
-                handleAnnotation(scheduleAnnotation, jobClass, jobKey)
+                val cronExpression = resolveEnvironmentPlaceholders(scheduleAnnotation.cron)
+
+                cronExpression.ifBlank { throw IllegalArgumentException("No cron expression provided for job $jobKey") }
+
+                scheduleCronJob(jobClass, jobKey, cronExpression)
 
                 newJobKeysSet.add(jobKey)
+
             }
         }
 
@@ -90,29 +71,11 @@ class JobScheduler(
         logger.info("Starting scheduler")
 
         scheduler.start()
+
     }
 
     private fun resolveEnvironmentPlaceholders(value: String): String {
         return applicationContext.environment.resolvePlaceholders(value)
-    }
-
-    // Get the root package for job scanning, defaulting to the package of the main application class
-    private fun determineJobsSearchPathRootPackage(): List<String> {
-        return simplyQuartzProperties.packagesToScan
-            ?: mainClassHolder.mainApplicationClass?.`package`?.name?.let { listOf(it) }
-            ?: throw IllegalStateException("Unable to determine base package for job scanning")
-    }
-
-    private fun handleAnnotation(
-        scheduleAnnotation: QuartzSchedule,
-        jobClass: Class<out Job>,
-        jobKey: JobKey
-    ) {
-        val cronExpression = resolveEnvironmentPlaceholders(scheduleAnnotation.cron)
-
-        cronExpression.ifBlank { throw IllegalArgumentException("No cron expression provided for job $jobKey") }
-
-        scheduleCronJob(jobClass, jobKey, cronExpression)
     }
 
     private fun scheduleCronJob(clazz: Class<out Job>, jobKey: JobKey, cronExpression: String) {
@@ -128,8 +91,10 @@ class JobScheduler(
             .build()
 
         if (scheduler.checkExists(jobKey)) {
+            logger.info("Rescheduling job ${jobKey.name} with schedule $cronExpression")
             scheduler.rescheduleJob(newTrigger.key, newTrigger)
         } else {
+            logger.info("Scheduling job  ${jobKey.name} with schedule $cronExpression")
             scheduler.scheduleJob(jobDetail, newTrigger)
         }
     }

--- a/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/JobScheduler.kt
@@ -15,7 +15,6 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.event.EventListener
 
-
 @Configuration
 @ConditionalOnProperty("simplyquartz.enabled", havingValue = "true")
 @EnableConfigurationProperties(SimplyQuartzProperties::class)
@@ -57,7 +56,6 @@ class JobScheduler(
                 scheduleCronJob(jobClass, jobKey, cronExpression)
 
                 newJobKeysSet.add(jobKey)
-
             }
         }
 
@@ -71,7 +69,6 @@ class JobScheduler(
         logger.info("Starting scheduler")
 
         scheduler.start()
-
     }
 
     private fun resolveEnvironmentPlaceholders(value: String): String {

--- a/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/QuartzSchedule.kt
@@ -1,10 +1,12 @@
 package com.valensas.simplyquartz
 
 import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
 
 @Scheduled
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
+@Component
 annotation class QuartzSchedule(
 
     val cron: String = "",

--- a/src/main/kotlin/com/valensas/simplyquartz/SimplyQuartzProperties.kt
+++ b/src/main/kotlin/com/valensas/simplyquartz/SimplyQuartzProperties.kt
@@ -5,5 +5,4 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("simplyquartz")
 class SimplyQuartzProperties {
     var enabled: Boolean = true
-    var packagesToScan: List<String>? = null
 }

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -6,12 +6,6 @@
       "type": "bool",
       "default": true,
       "sourceType": "com.valensas.simplyquartz.SimplyQuartzProperties"
-    },
-    {
-      "name": "simplyquartz.packagesToScan",
-      "type": "List<String>",
-      "default": [],
-      "sourceType": "com.valensas.simplyquartz.SimplyQuartzProperties"
     }
   ],
   "hints": []

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,1 @@
-com.valensas.simplyquartz.MainClassHolder
 com.valensas.simplyquartz.JobScheduler


### PR DESCRIPTION
Reflections prevented the library from being used in a native image and required extensive extra configuration. Now with these changes jobs are easily detected and works in a native image without extra configurations.

